### PR TITLE
Kill moods and introduce events

### DIFF
--- a/src/lib/components/Mapping/IntensityView.svelte
+++ b/src/lib/components/Mapping/IntensityView.svelte
@@ -1,136 +1,150 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
-	import IntensityGauge from './IntensityGauge.svelte';
-	import type { MappingItem, MappingValue } from './types';
+	import type { MappingIntensityValue, MappingItem } from './types';
 
 	export let items: MappingItem[] = [];
-	export let initialValues: MappingValue[] = [];
-	export let maxLevel = 3;
+	export let initialValues: MappingIntensityValue[] = [];
 	export let containerLabel = 'Intensity controls';
 
-	const dispatch = createEventDispatcher<{ change: MappingValue[] }>();
-	let focusedIndex = 0;
+	const dispatch = createEventDispatcher<{ change: MappingIntensityValue[] }>();
+	const MIN_INTENSITY = -3;
+	const MAX_INTENSITY = 3;
+
 	let allValues = new SvelteMap<string, number>();
 	let visibleValues = new SvelteMap<string, number>();
 	let visibleIds = new SvelteSet<string>();
-	let lastInitialValues: MappingValue[] = initialValues;
+	let lastInitialValues: MappingIntensityValue[] = initialValues;
+
+	const clamp = (value: number) =>
+		Math.max(MIN_INTENSITY, Math.min(MAX_INTENSITY, Math.round(value)));
 
 	$: if (initialValues !== lastInitialValues) {
-		allValues = new SvelteMap(initialValues.map(({ id, value }) => [id, value]));
+		const nextAll = new SvelteMap<string, number>();
+		for (const entry of initialValues) {
+			nextAll.set(entry.id, clamp(entry.value));
+		}
+		allValues = nextAll;
 		lastInitialValues = initialValues;
 	}
 
-	$: {
-		visibleIds = new SvelteSet(items.map((item) => item.id));
-		const nextVisible = new SvelteMap<string, number>();
+	$: visibleIds = new SvelteSet(items.map((item) => item.id));
+
+	$: visibleValues = (() => {
+		const next = new SvelteMap<string, number>();
 		for (const id of visibleIds) {
 			const existing = allValues.get(id);
 			if (existing !== undefined) {
-				nextVisible.set(id, existing);
+				next.set(id, existing);
 			}
 		}
-		visibleValues = nextVisible;
-	}
+		return next;
+	})();
 
-	$: {
-		if (items.length === 0) {
-			focusedIndex = 0;
-		} else if (focusedIndex > items.length - 1) {
-			focusedIndex = items.length - 1;
-		} else if (focusedIndex < 0) {
-			focusedIndex = 0;
-		}
-	}
+	$: entries = items.map((item) => ({
+		item,
+		value: visibleValues.get(item.id) ?? null
+	}));
 
 	function emitChange() {
-		const payload: MappingValue[] = Array.from(allValues.entries()).map(([id, value]) => ({
+		const payload: MappingIntensityValue[] = Array.from(allValues.entries()).map(([id, value]) => ({
 			id,
-			scale_type: 'intensity',
+			kind: 'intensity',
 			value
 		}));
 		dispatch('change', payload);
 	}
 
-	function setValue(id: string, value: number) {
+	function updateValue(id: string, rawValue: string) {
+		if (rawValue.trim() === '') {
+			setValue(id, null);
+			return;
+		}
+
+		const parsed = Number.parseInt(rawValue, 10);
+		if (Number.isNaN(parsed)) {
+			return;
+		}
+
+		const clamped = clamp(parsed);
+		setValue(id, clamped);
+	}
+
+	function handleInput(id: string, event: Event) {
+		const target = event.currentTarget as HTMLInputElement | null;
+		if (!target) return;
+		updateValue(id, target.value);
+	}
+
+	function handleBlur(id: string, event: FocusEvent) {
+		const target = event.currentTarget as HTMLInputElement | null;
+		if (!target) return;
+		const raw = target.value.trim();
+		if (raw === '') {
+			updateValue(id, '');
+			return;
+		}
+		const parsed = Number.parseInt(raw, 10);
+		if (Number.isNaN(parsed)) {
+			target.value = '';
+			updateValue(id, '');
+			return;
+		}
+		const clamped = clamp(parsed);
+		if (clamped !== parsed) {
+			target.value = String(clamped);
+		}
+		updateValue(id, target.value);
+	}
+
+	function setValue(id: string, value: number | null) {
 		const nextAll = new SvelteMap(allValues);
-		nextAll.set(id, value);
+		let changed = false;
+
+		if (value === null) {
+			changed = nextAll.delete(id);
+		} else {
+			const clamped = clamp(value);
+			const current = nextAll.get(id);
+			if (current !== clamped) {
+				nextAll.set(id, clamped);
+				changed = true;
+			}
+		}
+
+		if (!changed) return;
+
 		allValues = nextAll;
 
-		if (visibleIds.has(id)) {
-			const nextVisible = new SvelteMap(visibleValues);
-			nextVisible.set(id, value);
+		const nextVisible = new SvelteMap(visibleValues);
+		if (value === null) {
+			if (nextVisible.delete(id)) {
+				visibleValues = nextVisible;
+			}
+		} else if (visibleIds.has(id)) {
+			nextVisible.set(id, clamp(value));
 			visibleValues = nextVisible;
 		}
 
 		emitChange();
 	}
-
-	function adjustValueById(id: string, delta: number) {
-		const current = allValues.get(id) ?? 0;
-		const next = Math.max(0, Math.min(maxLevel, current + delta));
-		if (next === current) return;
-		setValue(id, next);
-	}
-
-	function resetValueById(id: string) {
-		const current = allValues.get(id) ?? 0;
-		if (current === 0) return;
-		setValue(id, 0);
-	}
-
-	function handleFocusRequest(index: number) {
-		if (items.length === 0) return;
-		const clamped = Math.max(0, Math.min(index, items.length - 1));
-		focusedIndex = clamped;
-	}
-
-	function handleGaugeChange(id: string, value: number) {
-		const clamped = Math.max(0, Math.min(maxLevel, value));
-		setValue(id, clamped);
-	}
-
-	function handleStep(index: number, id: string, delta: number) {
-		focusedIndex = index;
-		adjustValueById(id, delta);
-	}
-
-	function handleReset(index: number, id: string) {
-		focusedIndex = index;
-		resetValueById(id);
-	}
-
-	function handleNavigate(index: number, delta: number) {
-		focusedIndex = index;
-		handleFocusRequest(index + delta);
-	}
-
-	function handleJump(index: number, target: 'start' | 'end') {
-		focusedIndex = index;
-		if (items.length === 0) return;
-		handleFocusRequest(target === 'start' ? 0 : items.length - 1);
-	}
 </script>
 
 <div class="flex flex-col gap-2" role="group" aria-label={containerLabel}>
-	{#each items as item, i (item.id)}
-		<IntensityGauge
-			label={item.label}
-			value={visibleValues.get(item.id) ?? 0}
-			index={i}
-			{focusedIndex}
-			max={maxLevel}
-			on:change={(event: CustomEvent<{ index: number; value: number }>) =>
-				handleGaugeChange(item.id, event.detail.value)}
-			on:intensityStep={(event: CustomEvent<{ index: number; delta: number }>) =>
-				handleStep(event.detail.index, item.id, event.detail.delta)}
-			on:intensityReset={(event: CustomEvent<{ index: number }>) =>
-				handleReset(event.detail.index, item.id)}
-			on:intensityNavigate={(event: CustomEvent<{ index: number; delta: number }>) =>
-				handleNavigate(event.detail.index, event.detail.delta)}
-			on:intensityJump={(event: CustomEvent<{ index: number; target: 'start' | 'end' }>) =>
-				handleJump(event.detail.index, event.detail.target)}
-			on:focus={(event: CustomEvent<{ index: number }>) => handleFocusRequest(event.detail.index)}
-		/>
+	{#each entries as { item, value } (item.id)}
+		<label class="flex items-center gap-3 text-sm">
+			<span class="w-32 shrink-0 font-medium">{item.label}</span>
+			<input
+				type="number"
+				class="w-20 rounded border px-2 py-1"
+				min={MIN_INTENSITY}
+				max={MAX_INTENSITY}
+				step="1"
+				value={value ?? ''}
+				placeholder="—"
+				on:input={(event) => handleInput(item.id, event)}
+				on:blur={(event) => handleBlur(item.id, event)}
+			/>
+		</label>
 	{/each}
 </div>

--- a/src/lib/components/Mapping/MappingHeader.svelte
+++ b/src/lib/components/Mapping/MappingHeader.svelte
@@ -75,6 +75,6 @@
 
 {#if mode === 'intensity'}
 	<p class="mt-2 text-xs text-gray-500">
-		Astuce clavier : ↑/↓ pour changer de jauge, ←/→ pour ajuster, Backspace pour réinitialiser.
+		Astuce clavier&nbsp;: Tab pour naviguer, ↑/↓ pour ajuster, Suppr pour effacer.
 	</p>
 {/if}

--- a/src/lib/components/Mapping/SelectView.svelte
+++ b/src/lib/components/Mapping/SelectView.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 	import { SvelteSet } from 'svelte/reactivity';
-	import type { MappingItem, MappingValue } from './types';
+	import type { MappingItem, MappingSelectionValue } from './types';
 
 	export let items: MappingItem[] = [];
-	export let initialValues: MappingValue[] = [];
+	export let initialValues: MappingSelectionValue[] = [];
 
-	const dispatch = createEventDispatcher<{ change: MappingValue[] }>();
+	const dispatch = createEventDispatcher<{ change: MappingSelectionValue[] }>();
 	let selected = new SvelteSet<string>();
 
 	$: {
@@ -16,10 +16,9 @@
 	}
 
 	function emitChange() {
-		const values: MappingValue[] = Array.from(selected).map((id) => ({
+		const values: MappingSelectionValue[] = Array.from(selected).map((id) => ({
 			id,
-			scale_type: 'selection',
-			value: 1
+			kind: 'selection'
 		}));
 		dispatch('change', values);
 	}

--- a/src/lib/components/Mapping/types.ts
+++ b/src/lib/components/Mapping/types.ts
@@ -1,5 +1,3 @@
-export type ScaleType = 'selection' | 'intensity' | 'impact';
-
 export interface MappingItem {
 	id: string;
 	label: string;
@@ -7,8 +5,15 @@ export interface MappingItem {
 	icon?: string;
 }
 
-export interface MappingValue {
+export interface MappingSelectionValue {
 	id: string;
-	scale_type: ScaleType;
+	kind: 'selection';
+}
+
+export interface MappingIntensityValue {
+	id: string;
+	kind: 'intensity';
 	value: number;
 }
+
+export type MappingValue = MappingSelectionValue | MappingIntensityValue;

--- a/src/routes/api/events/+server.ts
+++ b/src/routes/api/events/+server.ts
@@ -1,0 +1,181 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+type EmotionPayload = {
+	emotion_id: string;
+	valence?: number;
+};
+
+type AssociationPayload = {
+	association_id: string;
+	valence?: number;
+};
+
+type UpsertEventPayload = {
+	p_profile_id: string;
+	p_kind: string;
+	p_valence: number;
+	p_occurrence_date: string;
+	p_occurrence_time: string | null;
+	p_name?: string;
+	p_description?: string;
+	p_emotions?: EmotionPayload[];
+	p_associations?: AssociationPayload[];
+};
+
+const clampValence = (value: number): number => {
+	if (!Number.isFinite(value)) return 0;
+	return Math.max(-3, Math.min(3, Math.round(value)));
+};
+
+const normalizeEventValence = (value: unknown): number => {
+	if (typeof value === 'number') {
+		return clampValence(value);
+	}
+
+	if (typeof value === 'string') {
+		const parsed = Number.parseInt(value, 10);
+		if (!Number.isNaN(parsed)) {
+			return clampValence(parsed);
+		}
+	}
+
+	return 0;
+};
+
+const normalizeOptionalValence = (value: unknown): number | undefined => {
+	if (value === null || value === undefined) return undefined;
+	if (typeof value === 'number') {
+		return clampValence(value);
+	}
+	if (typeof value === 'string' && value.trim() !== '') {
+		const parsed = Number.parseInt(value, 10);
+		if (!Number.isNaN(parsed)) {
+			return clampValence(parsed);
+		}
+	}
+	return undefined;
+};
+
+const normalizeText = (value: unknown): string => {
+	if (typeof value !== 'string') return '';
+	return value.trim();
+};
+
+const normalizeKind = (value: unknown): string => {
+	if (value === 'moment' || value === 'day') {
+		return value;
+	}
+	return typeof value === 'string' && value.trim().length > 0 ? value.trim() : 'day';
+};
+
+const normalizeTime = (value: unknown): string | null => {
+	if (value === null || value === undefined || value === '') {
+		return null;
+	}
+	if (typeof value === 'string') {
+		return value;
+	}
+	return null;
+};
+
+const normalizeEmotionCollection = (items: EmotionPayload[] | undefined): EmotionPayload[] => {
+	if (!Array.isArray(items)) return [];
+	const map = new Map<string, EmotionPayload>();
+
+	for (const item of items) {
+		if (!item || typeof item !== 'object') continue;
+		const emotionId = String((item as EmotionPayload).emotion_id ?? '').trim();
+		if (!emotionId) continue;
+
+		const normalized: EmotionPayload = {
+			emotion_id: emotionId
+		};
+
+		const valence = normalizeOptionalValence((item as EmotionPayload).valence);
+		if (valence !== undefined) {
+			normalized.valence = valence;
+		}
+
+		map.set(emotionId, normalized);
+	}
+
+	return Array.from(map.values());
+};
+
+const normalizeAssociationCollection = (
+	items: AssociationPayload[] | undefined
+): AssociationPayload[] => {
+	if (!Array.isArray(items)) return [];
+	const map = new Map<string, AssociationPayload>();
+
+	for (const item of items) {
+		if (!item || typeof item !== 'object') continue;
+		const associationId = String((item as AssociationPayload).association_id ?? '').trim();
+		if (!associationId) continue;
+
+		const normalized: AssociationPayload = {
+			association_id: associationId
+		};
+
+		const valence = normalizeOptionalValence((item as AssociationPayload).valence);
+		if (valence !== undefined) {
+			normalized.valence = valence;
+		}
+
+		map.set(associationId, normalized);
+	}
+
+	return Array.from(map.values());
+};
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	const { supabase, user } = locals;
+
+	if (!supabase || !user) {
+		return json({ message: 'Authentication required' }, { status: 401 });
+	}
+
+	let payload: UpsertEventPayload;
+	try {
+		payload = (await request.json()) as UpsertEventPayload;
+	} catch (err) {
+		return json(
+			{ message: 'Invalid JSON payload', details: err instanceof Error ? err.message : undefined },
+			{ status: 400 }
+		);
+	}
+
+	const requiredFields: Array<keyof UpsertEventPayload> = [
+		'p_kind',
+		'p_valence',
+		'p_occurrence_date'
+	];
+
+	for (const field of requiredFields) {
+		if (payload[field] === undefined || payload[field] === null || payload[field] === '') {
+			return json({ message: `Missing required field: ${field}` }, { status: 400 });
+		}
+	}
+
+	const rpcArgs: UpsertEventPayload = {
+		p_profile_id: user.id, // enforce authenticated profile
+		p_kind: normalizeKind(payload.p_kind),
+		p_valence: normalizeEventValence(payload.p_valence),
+		p_occurrence_date: payload.p_occurrence_date,
+		p_occurrence_time: normalizeTime(payload.p_occurrence_time),
+		p_name: normalizeText(payload.p_name),
+		p_description: normalizeText(payload.p_description),
+		p_emotions: normalizeEmotionCollection(payload.p_emotions),
+		p_associations: normalizeAssociationCollection(payload.p_associations)
+	};
+
+	const { data, error } = await supabase.rpc('upsert_event_full', rpcArgs);
+
+	if (error) {
+		console.error('upsert_event_full failed', error);
+		return json({ message: 'Unable to save event', details: error.message }, { status: 500 });
+	}
+
+	return json({ id: data ?? null });
+};


### PR DESCRIPTION
Moods model doesn't exist anymore. We now use the Events model. So in the moods/create page :

- kind → options are now: Moment, Day
- valence → [-3 to +3] like before
- date → the same
- time → the same
- emotions → keep filtering according to the valence
- associations → the same

But for the mapping component, there are no longer any scale_type or scale_value: it's nothing or a valence.

- If selected, just send the emotion_id/association_id without any value (Supabase will inherit the event valence to all selected ones).
- If intensity: implement a basic integer input that accepts from -3 to 3. User navigates with tab, and increase/decrease with up/down keys.

Check the api/events/server I started to implement to see what is expected from supabase.

Name and description are optional.

Resolve #53 